### PR TITLE
Automatic update of Newtonsoft.Json to 12.0.3

### DIFF
--- a/playground/GitHub-Action-Playground.csproj
+++ b/playground/GitHub-Action-Playground.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuKeeper has generated a major update of `Newtonsoft.Json` to `12.0.3` from `11.0.2`
`Newtonsoft.Json 12.0.3` was published at `2019-11-09T01:27:30Z`, 7 months ago

1 project update:
Updated `playground/GitHub-Action-Playground.csproj` to `Newtonsoft.Json` `12.0.3` from `11.0.2`

[Newtonsoft.Json 12.0.3 on NuGet.org](https://www.nuget.org/packages/Newtonsoft.Json/12.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
